### PR TITLE
Remove runtime scope from aws deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,21 +59,17 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
         </dependency>
-        <!-- Various auth stuff, instantiated by AWS SDK using reflection -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ssooidc</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sso</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
-            <scope>runtime</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Runtime dependencies are not present on the classpath when using the extension. As a result sso auth is not working.
Removing runtime scope solves the issue.